### PR TITLE
add simple faq endpoint

### DIFF
--- a/app/api/faqs.py
+++ b/app/api/faqs.py
@@ -1,0 +1,42 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from app.db.database import SessionLocal
+from app.models.faq import FAQ
+from pydantic import BaseModel
+
+router = APIRouter(prefix="/api/faqs", tags=["FAQs"])
+
+# Dependency to get DB session
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+# Request model
+class FAQCreate(BaseModel):
+    question: str
+    answer: str
+
+# Response model
+class FAQResponse(BaseModel):
+    id: int
+    question: str
+    answer: str
+
+    class Config:
+        from_attributes = True
+
+@router.post("/", response_model=FAQResponse)
+def create_faq(faq: FAQCreate, db: Session = Depends(get_db)):
+    db_faq = FAQ(question=faq.question, answer=faq.answer)
+    db.add(db_faq)
+    db.commit()
+    db.refresh(db_faq)
+    return db_faq
+
+@router.get("/", response_model=list[FAQResponse])
+def get_all_faqs(db: Session = Depends(get_db)):
+    return db.query(FAQ).all()
+

--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,9 @@
 from fastapi import FastAPI
+from app.api import faqs
 
 app = FastAPI(title="AI Support Draft API")
+
+app.include_router(faqs.router)
 
 @app.get("/")
 def read_root():


### PR DESCRIPTION
This pull request introduces a new FAQs API to the application, allowing users to create and retrieve frequently asked questions. The implementation includes a new router, request and response models, and integration with the main application.

### FAQs API Implementation:

* [`app/api/faqs.py`](diffhunk://#diff-76e2303fa088e04306d273b1b5634cda30449ecc17296a283ec817ba4c215789R1-R42): Added a new `APIRouter` for FAQs with endpoints to create (`POST /api/faqs/`) and retrieve all FAQs (`GET /api/faqs/`). Includes request (`FAQCreate`) and response (`FAQResponse`) models and database session management.

### Integration with Main Application:

* [`app/main.py`](diffhunk://#diff-990f7e4140fab1ad82afc787505090b64d4024e63a891405cd9085e7e6b249ddR2-R7): Integrated the FAQs router into the main FastAPI application by including `faqs.router`.